### PR TITLE
Fix llvm-mingw for amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,12 @@ RUN \
 
 # install a copy of mingw with aarch64 support to enable windows on arm64
 WORKDIR /llvm-mingw
+ARG TARGETARCH
 RUN \
-    wget "https://github.com/mstorsjo/llvm-mingw/releases/download/20220906/llvm-mingw-20220906-ucrt-ubuntu-18.04-aarch64.tar.xz" && \
-    tar -xvf llvm-mingw-20220906-ucrt-ubuntu-18.04-aarch64.tar.xz
+    if [ ${TARGETARCH} = "arm64" ]; then MINGW_ARCH=aarch64; else MINGW_ARCH=x86_64; fi && \
+    wget "https://github.com/mstorsjo/llvm-mingw/releases/download/20220906/llvm-mingw-20220906-ucrt-ubuntu-18.04-${MINGW_ARCH}.tar.xz" && \
+    tar -xvf llvm-mingw-20220906-ucrt-ubuntu-18.04-${MINGW_ARCH}.tar.xz && \
+    ln -s llvm-mingw-20220906-ucrt-ubuntu-18.04-${MINGW_ARCH} llvm-mingw
 
 FROM osx-cross-base AS osx-cross
 ARG OSX_CROSS_COMMIT

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,6 @@ manifest-create-base:
 manifest-create:
 	@echo "creating manifest $(IMAGE_NAME)"
 	docker manifest create $(IMAGE_NAME) $(foreach arch,$(SUBIMAGES), --amend $(IMAGE_NAME)-$(arch))
-	@echo "creating base manifest $(IMAGE_NAME)-base"
-	docker manifest create $(IMAGE_NAME)-base $(foreach arch,$(SUBIMAGES), --amend $(IMAGE_NAME)-base-$(arch))
 
 .PHONY: manifest-push-base
 manifest-push-base:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ with a `PKG_CONFIG_SYSROOT_DIR` set to `/var/target` (same rule apply to `-L`)
 | Linux       | armhf (GOARM=6) | arm-linux-gnueabihf-gcc | arm-linux-gnueabihf-g++ | Verification required |
 | Linux       | armhf (GOARM=7) | arm-linux-gnueabihf-gcc | arm-linux-gnueabihf-g++ |           ✅          |
 | Windows     | amd64           | x86_64-w64-mingw32-gcc  | x86_64-w64-mingw32-g++  |           ✅          |
-| Windows     | arm64           | /llvm-mingw/llvm-mingw-20220906-ucrt-ubuntu-18.04-aarch64/bin/aarch64-w64-mingw32-gcc | /llvm-mingw/llvm-mingw-20220906-ucrt-ubuntu-18.04-aarch64/bin/aarch64-w64-mingw32-g++ |          ✅           |
+| Windows     | arm64           | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-gcc | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-g++ |          ✅           |
 
 ## Docker
 


### PR DESCRIPTION
The original tarball I was downloading was only for `arm64`. Since the image is built for both `arm64` and `amd64`, download the appropriate tarball for the appropriate platform and symlink them both to an identical path so that `CC` and `CXX` can be the same either way.

Second commit also fixes another Makefile issue: `manifest-create` was duplicating `manifest-create-base`.