### PR TITLE
Add upx tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN \
         patch \
         mercurial \
         musl-tools \
+        upx-ucl \
  && apt -y autoremove \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Add upx tool to compress binary & docker images.

To enable it, add a post hook to your goreleaser build:

```
builds:
  - hooks:
      post:
        - upx "{{.Path}}"
```
