### PR TITLE
Make CC and CXX vars host architecture independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,66 +16,72 @@ Docker images are available on both [GitHub](https://ghcr.io/goreleaser/goreleas
 
 Images from version v1.17.4 are multi-arch. Supported hosts are listed in the table below. The `compiler` columns refer to what compiler arch you are using when you invoke the `gcc` and `g++` binaries on the host.
 
-| Host                 | Supported | `gcc` compiler         | `g++` compiler        |
-|----------------------|:---------:| ---------------------- | ----------------------|
-|  amd64               |     ✅    |  x86_64-linux-gnu-gcc  | x86_64-linux-gnu-g++  |
-|  arm64 (aka aarch64) |     ✅    |  aarch64-linux-gnu-gcc | aarch64-linux-gnu-gcc |  
+| Host                | Supported | `gcc` compiler        | `g++` compiler        |
+| ------------------- | :-------: | --------------------- | --------------------- |
+| amd64               |    ✅     | x86_64-linux-gnu-gcc  | x86_64-linux-gnu-g++  |
+| arm64 (aka aarch64) |    ✅     | aarch64-linux-gnu-gcc | aarch64-linux-gnu-gcc |
 
 To run build with CGO each entry requires some environment variables
 
 | Env variable             | value                                          |            required            | Notes                                                                                              |
-|--------------------------|------------------------------------------------|:------------------------------:|----------------------------------------------------------------------------------------------------|
+| ------------------------ | ---------------------------------------------- | :----------------------------: | -------------------------------------------------------------------------------------------------- |
 | `CGO_ENABLED`            | 1                                              |              Yes               | instead of specifying it in each build it can be set globally during docker run `-e CGO_ENABLED=1` |
 | `CC`                     | [see targets](#supported-toolchains/platforms) |            Optional            |
 | `CXX`                    | [see targets](#supported-toolchains/platforms) |            Optional            |
 | `PKG_CONFIG_SYSROOT_DIR` |                                                | Required if sysroot is present |
 | `PKG_CONFIG_PATH`        |                                                |            Optional            | List of directories containing pkg-config files                                                    |
 
-- **PKG_CONFIG_SYSROOT_DIR** modifies `-I`  and `-L` to use the directories located in target's sysroot.
+- **PKG_CONFIG_SYSROOT_DIR** modifies `-I` and `-L` to use the directories located in target's sysroot.
 - The value of `PKG_CONFIG_SYSROOT_DIR` is prefixed to `-I` and `-L`. For instance `-I/usr/include/libfoo` becomes `-I/var/target/usr/include/libfoo`
-with a `PKG_CONFIG_SYSROOT_DIR` set to `/var/target` (same rule apply to `-L`)
+  with a `PKG_CONFIG_SYSROOT_DIR` set to `/var/target` (same rule apply to `-L`)
 - **PKG_CONFIG_PATH** - A colon-separated list of directories to search for `.pc` files.
 
 ## Supported toolchains/platforms
 
 | Platform    | Arch            | CC                                                 | CXX                                                |       Verified        |
-|-------------|-----------------|----------------------------------------------------|----------------------------------------------------|:---------------------:|
-| Darwin      | amd64           | o64-clang                                          | o64-clang++                                        |           ✅           |
-| Darwin (M1) | arm64           | oa64-clang                                         | oa64-clang++                                       |           ✅           |
-| Linux       | amd64           | x86_64-linux-gnu-gcc                               | x86_64-linux-gnu-g++                               |           ✅           |
-| Linux       | arm64           | aarch64-linux-gnu-gcc                              | aarch64-linux-gnu-g++                              |           ✅           |
+| ----------- | --------------- | -------------------------------------------------- | -------------------------------------------------- | :-------------------: |
+| Darwin      | amd64           | o64-clang                                          | o64-clang++                                        |          ✅           |
+| Darwin (M1) | arm64           | oa64-clang                                         | oa64-clang++                                       |          ✅           |
+| Linux       | amd64           | x86_64-linux-gnu-gcc                               | x86_64-linux-gnu-g++                               |          ✅           |
+| Linux       | arm64           | aarch64-linux-gnu-gcc                              | aarch64-linux-gnu-g++                              |          ✅           |
 | Linux       | armhf (GOARM=5) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            | Verification required |
 | Linux       | armhf (GOARM=6) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            | Verification required |
-| Linux       | armhf (GOARM=7) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            |           ✅           |
-| Windows     | amd64           | x86_64-w64-mingw32-gcc                             | x86_64-w64-mingw32-g++                             |           ✅           |
-| Windows     | arm64           | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-gcc | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-g++ |           ✅           |
+| Linux       | armhf (GOARM=7) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            |          ✅           |
+| Windows     | amd64           | x86_64-w64-mingw32-gcc                             | x86_64-w64-mingw32-g++                             |          ✅           |
+| Windows     | arm64           | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-gcc | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-g++ |          ✅           |
 
 ## Docker
 
 ### Environment variables
+
 - [Goreleaser](https://github.com/goreleaser/goreleaser) variables
 - `GPG_KEY` (optional) - defaults to /secrets/key.gpg. ignored if file not found
 - `DOCKER_CREDS_FILE` (optional) - path to JSON file with docker login credentials. useful when push to multiple docker registries required
 - `DOCKER_FAIL_ON_LOGIN_ERROR` (optional) - fail on docker login error
 
 ### Login to registry
+
 #### Github Actions
+
 Use [docker login](https://github.com/docker/login-action) to auth to repos and mount docker config file. For example
+
 ```shell
 docker run -v $(HOME)/.docker/config.json:/root/.docker/config.json ...
 ```
 
 #### Docker creds file
-To login from within `goreleaser-cross` container create creds file. 
+
+To login from within `goreleaser-cross` container create creds file.
+
 ```json
 {
-	"registries": [
-		{
-			"user" : "<username>",
-			"pass" : "<password>",
-			"registry" : "<registry url>" // for example ghcr.io
-		}
-	]
+  "registries": [
+    {
+      "user": "<username>",
+      "pass": "<password>",
+      "registry": "<registry url>" // for example ghcr.io
+    }
+  ]
 }
 ```
 
@@ -88,9 +94,10 @@ running Debian Buster.
 - install all required dev packages. for this example we will install libftdi1-dev, libusb-1.0-0-dev and opencv4
   ```bash
   ./sysroot-rsync.sh pi@<ipaddress> <local destination>
-  ``` 
+  ```
 
 ### sshfs
+
 Though `sshfs` is a good way to test sysroot before running rsync it introduces cons. Some packages are creating absolute links and thus pointing to wrong files when mounted (
 or appear as broken). For example RPI4 running Debian Buster the library `/usr/lib/x86_x64-gnu-linux/libpthread.so` is symlink to `/lib/x86_x64-gnu-linux/libpthread.so` instead
 of `../../../lib/x86_x64-gnu-linux/libpthread.so`.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This project is rather cookbook combing various projects into one. Special to [o
 
 Docker images are available on both [GitHub](https://ghcr.io/goreleaser/goreleaser-cross) and [Docker hub](https://hub.docker.com/r/goreleaser/goreleaser-cross).
 
-Images from version v1.17.4 are multi-arch. Supported host are listed in the table below
+Images from version v1.17.4 are multi-arch. Supported hosts are listed in the table below. The `compiler` columns refer to what compiler arch you are using when you invoke the `gcc` and `g++` binaries on the host.
 
-| Host                 | Supported |
-|----------------------|:---------:|
-|  amd64               |     ✅     |
-|  arm64 (aka aarch64) |     ✅     |
+| Host                 | Supported | `gcc` compiler         | `g++` compiler        |
+|----------------------|:---------:| ---------------------- | ----------------------|
+|  amd64               |     ✅    |  x86_64-linux-gnu-gcc  | x86_64-linux-gnu-g++  |
+|  arm64 (aka aarch64) |     ✅    |  aarch64-linux-gnu-gcc | aarch64-linux-gnu-gcc |  
 
 To run build with CGO each entry requires some environment variables
 
@@ -42,7 +42,7 @@ with a `PKG_CONFIG_SYSROOT_DIR` set to `/var/target` (same rule apply to `-L`)
 |-------------|-----------------|----------------------------------------------------|----------------------------------------------------|:---------------------:|
 | Darwin      | amd64           | o64-clang                                          | o64-clang++                                        |           ✅           |
 | Darwin (M1) | arm64           | oa64-clang                                         | oa64-clang++                                       |           ✅           |
-| Linux       | amd64           | gcc                                                | g++                                                |           ✅           |
+| Linux       | amd64           | x86_64-linux-gnu-gcc                               | x86_64-linux-gnu-g++                               |           ✅           |
 | Linux       | arm64           | aarch64-linux-gnu-gcc                              | aarch64-linux-gnu-g++                              |           ✅           |
 | Linux       | armhf (GOARM=5) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            | Verification required |
 | Linux       | armhf (GOARM=6) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            | Verification required |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Should you wish to see working [examples](#examples) instead of reading
 
 ## Credits
 
-This project is rather cookbook combing various projects into one. Special to [osxcross](https://github.com/tpoechtrager/osxcross) for amazing cross-compile environment for OSX.
+This project is a cookbook combining various projects into one. Special thanks to [osxcross](https://github.com/tpoechtrager/osxcross) for an amazing cross-compile environment for OSX.
 
 ## Docker
 
@@ -18,17 +18,16 @@ Images from version v1.17.4 are multi-arch. Supported hosts are listed in the ta
 
 | Host                | Supported | `gcc` compiler        | `g++` compiler        |
 | ------------------- | :-------: | --------------------- | --------------------- |
-| amd64               |    ✅     | x86_64-linux-gnu-gcc  | x86_64-linux-gnu-g++  |
-| arm64 (aka aarch64) |    ✅     | aarch64-linux-gnu-gcc | aarch64-linux-gnu-gcc |
+| amd64               |     ✅     | x86_64-linux-gnu-gcc  | x86_64-linux-gnu-g++  |
+| arm64 (aka aarch64) |     ✅     | aarch64-linux-gnu-gcc | aarch64-linux-gnu-gcc |
 
-To run build with CGO each entry requires some environment variables
-
-| Env variable             | value                                          |            required            | Notes                                                                                              |
+Below are additional environment variables to set when cross compiling with CGO.
+| Env variable             | Value                                          |            Required            | Notes                                                                                              |
 | ------------------------ | ---------------------------------------------- | :----------------------------: | -------------------------------------------------------------------------------------------------- |
-| `CGO_ENABLED`            | 1                                              |              Yes               | instead of specifying it in each build it can be set globally during docker run `-e CGO_ENABLED=1` |
-| `CC`                     | [see targets](#supported-toolchains/platforms) |            Optional            |
-| `CXX`                    | [see targets](#supported-toolchains/platforms) |            Optional            |
-| `PKG_CONFIG_SYSROOT_DIR` |                                                | Required if sysroot is present |
+| `CGO_ENABLED`            | 1                                              |              Yes               | Instead of specifying it in each build it can be set globally during docker run `-e CGO_ENABLED=1` |
+| `CC`                     | [see targets](#supported-toolchains/platforms) |            Optional            |                                                                                                    |
+| `CXX`                    | [see targets](#supported-toolchains/platforms) |            Optional            |                                                                                                    |
+| `PKG_CONFIG_SYSROOT_DIR` |                                                | Required if sysroot is present |                                                                                                    |
 | `PKG_CONFIG_PATH`        |                                                |            Optional            | List of directories containing pkg-config files                                                    |
 
 - **PKG_CONFIG_SYSROOT_DIR** modifies `-I` and `-L` to use the directories located in target's sysroot.
@@ -40,15 +39,15 @@ To run build with CGO each entry requires some environment variables
 
 | Platform    | Arch            | CC                                                 | CXX                                                |       Verified        |
 | ----------- | --------------- | -------------------------------------------------- | -------------------------------------------------- | :-------------------: |
-| Darwin      | amd64           | o64-clang                                          | o64-clang++                                        |          ✅           |
-| Darwin (M1) | arm64           | oa64-clang                                         | oa64-clang++                                       |          ✅           |
-| Linux       | amd64           | x86_64-linux-gnu-gcc                               | x86_64-linux-gnu-g++                               |          ✅           |
-| Linux       | arm64           | aarch64-linux-gnu-gcc                              | aarch64-linux-gnu-g++                              |          ✅           |
+| Darwin      | amd64           | o64-clang                                          | o64-clang++                                        |           ✅           |
+| Darwin (M1) | arm64           | oa64-clang                                         | oa64-clang++                                       |           ✅           |
+| Linux       | amd64           | x86_64-linux-gnu-gcc                               | x86_64-linux-gnu-g++                               |           ✅           |
+| Linux       | arm64           | aarch64-linux-gnu-gcc                              | aarch64-linux-gnu-g++                              |           ✅           |
 | Linux       | armhf (GOARM=5) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            | Verification required |
 | Linux       | armhf (GOARM=6) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            | Verification required |
-| Linux       | armhf (GOARM=7) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            |          ✅           |
-| Windows     | amd64           | x86_64-w64-mingw32-gcc                             | x86_64-w64-mingw32-g++                             |          ✅           |
-| Windows     | arm64           | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-gcc | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-g++ |          ✅           |
+| Linux       | armhf (GOARM=7) | arm-linux-gnueabihf-gcc                            | arm-linux-gnueabihf-g++                            |           ✅           |
+| Windows     | amd64           | x86_64-w64-mingw32-gcc                             | x86_64-w64-mingw32-g++                             |           ✅           |
+| Windows     | arm64           | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-gcc | /llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-g++ |           ✅           |
 
 ## Docker
 
@@ -56,20 +55,20 @@ To run build with CGO each entry requires some environment variables
 
 - [Goreleaser](https://github.com/goreleaser/goreleaser) variables
 - `GPG_KEY` (optional) - defaults to /secrets/key.gpg. ignored if file not found
-- `DOCKER_CREDS_FILE` (optional) - path to JSON file with docker login credentials. useful when push to multiple docker registries required
+- `DOCKER_CREDS_FILE` (optional) - path to JSON file with docker login credentials. Useful when push to multiple docker registries required
 - `DOCKER_FAIL_ON_LOGIN_ERROR` (optional) - fail on docker login error
 
 ### Login to registry
 
 #### Github Actions
 
-Use [docker login](https://github.com/docker/login-action) to auth to repos and mount docker config file. For example
+Use [docker login](https://github.com/docker/login-action) to auth to repos and mount docker config file. For example:
 
 ```shell
 docker run -v $(HOME)/.docker/config.json:/root/.docker/config.json ...
 ```
 
-#### Docker creds file
+#### Docker Creds file
 
 To login from within `goreleaser-cross` container create creds file.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Should you wish to see working [examples](#examples) instead of reading
 
 ## Credits
 
-This project is a cookbook combining various projects into one. Special thanks to [osxcross](https://github.com/tpoechtrager/osxcross) for an amazing cross-compile environment for OSX.
+This project is rather a cookbook combining various projects into one. Special thanks to [osxcross](https://github.com/tpoechtrager/osxcross) for an amazing cross-compile environment for OSX.
 
 ## Docker
 


### PR DESCRIPTION
Hi there, thanks for making this project. It saved me a bunch of time. One big thing i ran into while using an arm64 based host is that the `CC` and `CCX` variable is host arch specific when targeting `g++` and `gcc`. I changed your table so that no matter which host you're on, it uses the right compiler arch type.


- Make CC/CXX references host platform independent
- Make formatting consistent
- Grammar and spacing fixes
