### PR TITLE
switch cosign registry from GCR to GHCR

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,7 +2,7 @@ ARG COSIGN_VERSION
 ARG COSIGN_SHA256
 ARG TOOLCHAINS_VERSION
 
-FROM gcr.io/projectsigstore/cosign:v$COSIGN_VERSION@sha256:$COSIGN_SHA256 as cosign
+FROM ghcr.io/sigstore/cosign/cosign:v$COSIGN_VERSION@sha256:$COSIGN_SHA256 as cosign
 
 FROM ghcr.io/goreleaser/goreleaser-cross-toolchains:$TOOLCHAINS_VERSION
 


### PR DESCRIPTION
This changes the Dockerfile to pull the cosign container image from GHCR instead of Google Cloud. This helps the Sigstore team manage their cloud spend (as GHCR is provided for free and Google Cloud Artifact Registry is not).

Note the container hash does not change and images are posted to both locations upon cosign's release process.