### PR TITLE
Docs and fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+To build and publish all images, run:
+
+```sh
+make release-base release-goreleaser release-goreleaserpro
+```

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -18,6 +18,7 @@ RUN \
     echo "Starting image build for Debian" \
  && sed -ri "s/(httpredir|deb).debian.org/${APT_MIRROR:-deb.debian.org}/g" /etc/apt/sources.list \
  && sed -ri "s/(security).debian.org/${APT_MIRROR:-security.debian.org}/g" /etc/apt/sources.list \
+ && sed -ri "s/^deb /deb [arch=$TARGETARCH] /" /etc/apt/sources.list \
  && apt-get update \
  && apt-get install --no-install-recommends -y -q \
     software-properties-common \


### PR DESCRIPTION
for some reason, when I tried to build it locally, apt was trying mirrors for ppc64 and all possible arches.

gpt5 got that solution, i understand why it works, but still don't know why it was happening.

anyway, also documented how to build & push locally.