### PR TITLE
fix: goreleaser sends the full tag (with v prefix)

### DIFF
--- a/.github/workflows/goreleaser-bump.yaml
+++ b/.github/workflows/goreleaser-bump.yaml
@@ -33,6 +33,6 @@ jobs:
       - name: Commit new version
         run: |
           if git add .env > /dev/null 2>&1; then
-            git commit -m "feat: bump goreleaser to v${{ github.event.inputs.tag }}"
+            git commit -m "feat: bump goreleaser to ${{ github.event.inputs.tag }}"
             git push origin master
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GORELEASER_VERSION
 ARG GORELEASER_DISTRIBUTION=""
 ARG BASE_VERSION=latest
 
-FROM ghcr.io/goreleaser/goreleaser$GORELEASER_DISTRIBUTION:v$GORELEASER_VERSION AS goreleaser
+FROM ghcr.io/goreleaser/goreleaser$GORELEASER_DISTRIBUTION:$GORELEASER_VERSION AS goreleaser
 
 FROM ghcr.io/goreleaser/goreleaser-cross-base:$BASE_VERSION
 


### PR DESCRIPTION
see: https://github.com/goreleaser/goreleaser-cross/commit/6e5189afc07eca607bd110a72e39e184ee2b76ce